### PR TITLE
Add meaningful error msg for issue 18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,113 @@
-MANIFEST
-.tox
 doc/build
 tmp
 benchmark/benchmarks.db
+
+#### joe made this: http://goel.io/joe
+
+#####=== Python ===#####
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+

--- a/sexpdata.py
+++ b/sexpdata.py
@@ -528,6 +528,14 @@ class ExpectNothing(Exception):
             "Got: {0!r}", got))
 
 
+class ExpectSExp(Exception):
+
+    def __init__(self, pos):
+        super(ExpectSExp, self).__init__(uformat(
+            'No s-exp is found after an apostrophe'
+            ' at position {0}', pos))
+
+
 class Parser(object):
 
     closing_brackets = set(BRACKETS.values())
@@ -642,7 +650,10 @@ class Parser(object):
             elif c in self.closing_brackets:
                 break
             elif c == "'":
-                (i, subsexp) = self.parse_sexp(i + 1)
+                next_parse_start = i + 1
+                (i, subsexp) = self.parse_sexp(next_parse_start)
+                if not subsexp:
+                    raise ExpectSExp(next_parse_start - 1)
                 append(Quoted(subsexp[0]))
                 sexp.extend(subsexp[1:])
             elif c == self.line_comment:

--- a/test_sexpdata.py
+++ b/test_sexpdata.py
@@ -2,11 +2,11 @@
 
 from sexpdata import (
     PY3,
-    ExpectClosingBracket, ExpectNothing,
+    ExpectClosingBracket, ExpectNothing, ExpectSExp,
     parse, tosexp, Symbol, String, Quoted, bracket,
 )
 import unittest
-from nose.tools import eq_, raises
+from nose.tools import eq_, raises, assert_raises
 
 
 ### Python 3 compatibility
@@ -170,3 +170,18 @@ def test_no_eol_after_comment():
 def test_issue_4():
     yield (compare_parsed, "(0 ;; (\n)", [[0]])
     yield (compare_parsed, "(0;; (\n)", [[0]])
+
+
+def test_issue_18():
+    import sexpdata
+    sexp = "(foo)'   "
+    with assert_raises(ExpectSExp) as raised:
+        sexpdata.parse(sexp)
+    msg = raised.exception.args[0]
+    eq_(msg, 'No s-exp is found after an apostrophe at position 5')
+
+    sexp = "'   "
+    with assert_raises(ExpectSExp) as raised:
+        sexpdata.parse(sexp)
+    msg = raised.exception.args[0]
+    eq_(msg, 'No s-exp is found after an apostrophe at position 0')

--- a/tox.ini
+++ b/tox.ini
@@ -3,4 +3,5 @@ envlist = py26, py27, py32
 [testenv]
 deps =
   nose
-commands = nosetests --with-doctest
+  pudb
+commands = nosetests {posargs:--with-doctest}


### PR DESCRIPTION
Previously an apostrophe followed by nothing else would raise a cryptic `IndexError` from inside the parser (see issue #18).