### PR TITLE
Support formatting output as a tree

### DIFF
--- a/sexpdata.py
+++ b/sexpdata.py
@@ -77,7 +77,7 @@ __all__ = [
 ]
 
 import re
-from collections import namedtuple, Iterable, Mapping
+from collections import namedtuple, Iterable, Mapping, Sequence
 from itertools import chain
 from string import whitespace
 
@@ -502,11 +502,13 @@ class Delimiters(namedtuple('Delimiters', 'I')):
 
         if isinstance(x, Mapping):
             plist_pairs = ((Symbol(':' + k), v) for k, v in x.items())
-            return tuple.__new__(cls, (chain.from_iterable(plist_pairs),))
-        elif not isinstance(x, (unicode, bytes)) and isinstance(x, Iterable):
-            return tuple.__new__(cls, (x,))
-        else:
+            return tuple.__new__(cls, (tuple(chain.from_iterable(plist_pairs)),))
+        elif isinstance(x, (unicode, bytes)) or not isinstance(x, Iterable):
             return tuple.__new__(cls, ((x,),)) # unary *args
+        elif isinstance(x, Sequence):
+            return tuple.__new__(cls, (x,))
+        else: # isinstance(x, Iterable)
+            return tuple.__new__(cls, (tuple(x),))
 
     @staticmethod
     def from_opener(opener, val):

--- a/test_sexpdata.py
+++ b/test_sexpdata.py
@@ -61,6 +61,13 @@ def test_identity():
     for data in data_identity:
         yield (check_identity, data)
 
+def check_identity_pretty_print(obj):
+    eq_(parse(tosexp(obj, pretty_print=True))[0], obj)
+
+def test_identity_pretty_print():
+    for data in data_identity:
+        yield (check_identity_pretty_print, data)
+
 
 class BaseTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Fixes #28.

Each set of delimeters (`Brackets` or `Parens`) increases the indent by one level.

```
>>> from sexpdata import *
>>> print(dumps([Symbol('level_0'), Brackets(Symbol('level_1'), 'foo', 'bar'), 'baz'], format_tree=True))
(
  level_0
  [
    level_1
    "foo"
    "bar"
  ]
  "baz"
)
>>>
```