### PR TITLE
Port tests to pytest + CI update + pyproject.toml

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,5 +32,5 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: x64
       - run: python setup.py install
-      - run: pip install nose
-      - run: nosetests --with-doctest
+      - run: pip install nose pytest
+      - run: pytest --doctest-modules sexpdata.py test_sexpdata.py

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,6 +29,5 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-      - run: python setup.py install
-      - run: pip install pytest
+      - run: pip install . pytest
       - run: pytest --doctest-modules sexpdata.py test_sexpdata.py

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,19 +9,17 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - 3.6
           - 3.7
           - 3.8
           - 3.9
-          - pypy-3.6
-          - pypy-3.7
+          - "3.10"
+          - "3.11"
+          - pypy-3.8
+          - pypy-3.9
         os:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        exclude:
-          - os: macos-latest
-            python-version: 'pypy-3.6'
     runs-on:  ${{ matrix.os }}
     name: ${{ matrix.os }} @ ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,5 +30,5 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: x64
       - run: python setup.py install
-      - run: pip install nose pytest
+      - run: pip install pytest
       - run: pytest --doctest-modules sexpdata.py test_sexpdata.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/test_sexpdata.py
+++ b/test_sexpdata.py
@@ -7,13 +7,13 @@ from sexpdata import (
     parse, tosexp, Symbol, String, Quoted, bracket,
 )
 import unittest
-from nose.tools import eq_, raises, assert_raises
+from nose.tools import raises, assert_raises
 
 
 ### Test utils
 
 def compare_parsed(sexp, obj):
-    eq_(parse(sexp), obj)
+    assert parse(sexp) == obj
 
 
 ### Test cases
@@ -54,7 +54,7 @@ data_identity += map(lambda x: x[1], String._lisp_quoted_specials)
 
 
 def check_identity(obj):
-    eq_(parse(tosexp(obj))[0], obj)
+    assert parse(tosexp(obj))[0] == obj
 
 
 def test_identity():
@@ -62,7 +62,7 @@ def test_identity():
         yield (check_identity, data)
 
 def check_identity_pretty_print(obj):
-    eq_(parse(tosexp(obj, pretty_print=True))[0], obj)
+    assert parse(tosexp(obj, pretty_print=True))[0] == obj
 
 def test_identity_pretty_print():
     for data in data_identity:
@@ -139,25 +139,25 @@ class TestUnicode(BaseTestCase):
 
 
 def test_tosexp_str_as():
-    yield (eq_, tosexp('a', str_as='symbol'), 'a')
-    yield (eq_, tosexp(['a'], str_as='symbol'), '(a)')
-    yield (eq_, tosexp('a'), '"a"')
-    yield (eq_, tosexp(['a']), '("a")')
-    yield (eq_, tosexp(Quoted('a')), '\'"a"')
-    yield (eq_, tosexp(Quoted(['a']), str_as='symbol'), '\'(a)')
-    yield (eq_, tosexp([Quoted('a')], str_as='symbol'), '(\'a)')
-    yield (eq_, tosexp(Quoted('a'), str_as='symbol'), '\'a')
-    yield (eq_, tosexp(Quoted(['a'])), '\'("a")')
-    yield (eq_, tosexp([Quoted('a')]), '(\'"a")')
+    assert tosexp('a', str_as='symbol') == 'a'
+    assert tosexp(['a'], str_as='symbol') == '(a)'
+    assert tosexp('a') == '"a"'
+    assert tosexp(['a']) == '("a")'
+    assert tosexp(Quoted('a')) == '\'"a"'
+    assert tosexp(Quoted(['a']), str_as='symbol') == '\'(a)'
+    assert tosexp([Quoted('a')], str_as='symbol') == '(\'a)'
+    assert tosexp(Quoted('a'), str_as='symbol') == '\'a'
+    assert tosexp(Quoted(['a'])) == '\'("a")'
+    assert tosexp([Quoted('a')]) == '(\'"a")'
 
 
 def test_tosexp_tuple_as():
-    yield (eq_, tosexp(('a', 'b')), '("a" "b")')
-    yield (eq_, tosexp(('a', 'b'), tuple_as='array'), '["a" "b"]')
-    yield (eq_, tosexp([('a', 'b')]), '(("a" "b"))')
-    yield (eq_, tosexp([('a', 'b')], tuple_as='array'), '(["a" "b"])')
-    yield (eq_, tosexp(Quoted(('a',))), '\'("a")')
-    yield (eq_, tosexp(Quoted(('a',)), tuple_as='array'), '\'["a"]')
+    assert tosexp(('a', 'b')) == '("a" "b")'
+    assert tosexp(('a', 'b'), tuple_as='array') == '["a" "b"]'
+    assert tosexp([('a', 'b')]) == '(("a" "b"))'
+    assert tosexp([('a', 'b')], tuple_as='array') == '(["a" "b"])'
+    assert tosexp(Quoted(('a',))) == '\'("a")'
+    assert tosexp(Quoted(('a',)), tuple_as='array') == '\'["a"]'
 
 
 @raises(ValueError)
@@ -178,7 +178,7 @@ def test_not_enough_brackets():
 
 
 def test_no_eol_after_comment():
-    eq_(parse('a ; comment'), [Symbol('a')])
+    assert parse('a ; comment') == [Symbol('a')]
 
 
 def test_issue_4():
@@ -192,10 +192,10 @@ def test_issue_18():
     with assert_raises(ExpectSExp) as raised:
         sexpdata.parse(sexp)
     msg = raised.exception.args[0]
-    eq_(msg, 'No s-exp is found after an apostrophe at position 5')
+    assert msg == 'No s-exp is found after an apostrophe at position 5'
 
     sexp = "'   "
     with assert_raises(ExpectSExp) as raised:
         sexpdata.parse(sexp)
     msg = raised.exception.args[0]
-    eq_(msg, 'No s-exp is found after an apostrophe at position 0')
+    assert msg == 'No s-exp is found after an apostrophe at position 0'

--- a/test_sexpdata.py
+++ b/test_sexpdata.py
@@ -11,12 +11,6 @@ import unittest
 import pytest
 
 
-### Test utils
-
-def compare_parsed(sexp, obj):
-    assert parse(sexp) == obj
-
-
 ### Test cases
 
 data_identity = [
@@ -54,20 +48,14 @@ data_identity += map(lambda x: x[0], String._lisp_quoted_specials)
 data_identity += map(lambda x: x[1], String._lisp_quoted_specials)
 
 
-def check_identity(obj):
-    assert parse(tosexp(obj))[0] == obj
-
-
 def test_identity():
     for data in data_identity:
-        yield (check_identity, data)
+        assert parse(tosexp(data))[0] == data
 
-def check_identity_pretty_print(obj):
-    assert parse(tosexp(obj, pretty_print=True))[0] == obj
 
 def test_identity_pretty_print():
     for data in data_identity:
-        yield (check_identity_pretty_print, data)
+        assert parse(tosexp(data, pretty_print=True))[0] == data
 
 
 class BaseTestCase(unittest.TestCase):
@@ -185,8 +173,8 @@ def test_no_eol_after_comment():
 
 
 def test_issue_4():
-    yield (compare_parsed, "(0 ;; (\n)", [[0]])
-    yield (compare_parsed, "(0;; (\n)", [[0]])
+    assert parse("(0 ;; (\n)") == [[0]]
+    assert parse("(0;; (\n)") == [[0]]
 
 
 def test_issue_18():

--- a/test_sexpdata.py
+++ b/test_sexpdata.py
@@ -4,10 +4,11 @@ from __future__ import unicode_literals
 from sexpdata import (
     PY3,
     ExpectClosingBracket, ExpectNothing, ExpectSExp,
-    parse, tosexp, Symbol, String, Quoted, bracket,
+    parse, tosexp, Symbol, String, Quoted, bracket, Parens,
 )
 import unittest
-from nose.tools import raises, assert_raises
+
+import pytest
 
 
 ### Test utils
@@ -160,21 +161,23 @@ def test_tosexp_tuple_as():
     assert tosexp(Quoted(('a',)), tuple_as='array') == '\'["a"]'
 
 
-@raises(ValueError)
 def test_tosexp_value_errors():
-    tosexp((), tuple_as='')
-    tosexp('', str_as='')
-    tosexp(Parens())
+    with pytest.raises(ValueError):
+        tosexp((), tuple_as='')
+    with pytest.raises(ValueError):
+        tosexp('', str_as='')
+    with pytest.raises(ValueError):
+        tosexp(Parens())
 
 
-@raises(ExpectNothing)
 def test_too_many_brackets():
-    parse("(a b))")
+    with pytest.raises(ExpectNothing):
+        parse("(a b))")
 
 
-@raises(ExpectClosingBracket)
 def test_not_enough_brackets():
-    parse("(a (b)")
+    with pytest.raises(ExpectClosingBracket):
+        parse("(a (b)")
 
 
 def test_no_eol_after_comment():
@@ -189,13 +192,11 @@ def test_issue_4():
 def test_issue_18():
     import sexpdata
     sexp = "(foo)'   "
-    with assert_raises(ExpectSExp) as raised:
+    with pytest.raises(ExpectSExp, match='No s-exp is found after an '
+                                         'apostrophe at position 5'):
         sexpdata.parse(sexp)
-    msg = raised.exception.args[0]
-    assert msg == 'No s-exp is found after an apostrophe at position 5'
 
     sexp = "'   "
-    with assert_raises(ExpectSExp) as raised:
+    with pytest.raises(ExpectSExp, match='No s-exp is found after an '
+                                         'apostrophe at position 0'):
         sexpdata.parse(sexp)
-    msg = raised.exception.args[0]
-    assert msg == 'No s-exp is found after an apostrophe at position 0'

--- a/tox.ini
+++ b/tox.ini
@@ -4,4 +4,5 @@ envlist = py33, py34, py36
 deps =
   nose
   pudb
-commands = nosetests {posargs:--with-doctest}
+  pytest
+commands = pytest {posargs:--doctest-modules sexpdata.py test_sexpdata.py}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
 envlist = py37, py38, py39, py310, py311, pypy3
+isolated_build = True
+
 [testenv]
 deps =
   pudb

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 envlist = py37, py38, py39, py310, py311, pypy3
 [testenv]
 deps =
-  nose
   pudb
   pytest
 commands = pytest {posargs:--doctest-modules sexpdata.py test_sexpdata.py}

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,7 @@
 [tox]
-envlist = py27, py33, py34, py36
+envlist = py33, py34, py36
 [testenv]
 deps =
   nose
   pudb
-  py27: doctest-ignore-unicode
 commands = nosetests {posargs:--with-doctest}
-[testenv:py27]
-commands = nosetests {posargs:--with-doctest --with-doctest-ignore-unicode --doctest-options='+IGNORE_UNICODE'}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py33, py34, py36
+envlist = py37, py38, py39, py310, py311, pypy3
 [testenv]
 deps =
   nose


### PR DESCRIPTION
Here's a batch of changes to modernize the build and test infrastructure. I've split them into small commits with minimal changes, so you can apply a subset if you don't like them all. Basically:

- I've updated tox and GitHub Actions to test using currently non-EOL Python impls — 3.7 to 3.11 and PyPy-3.8 + -3.9.
- I've ported tests from nose to pytest with minimal changes
- I've added a minimal `pyproject.toml` to indicate how to build it via PEP517 tools and replaced obsolete `setup.py` install call

Fixes #32.