### PR TITLE
Fix conditional singledispatch requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,6 @@ from distutils.core import setup
 with open('README.rst') as f:
     long_description = f.read()
 
-install_requires = []
-if sys.version.split(" ")[0] < "3.4":
-    install_requires.append('singledispatch')
-
 setup(
     name='sexpdata',
     version='0.0.4',
@@ -36,5 +32,7 @@ setup(
         "Programming Language :: Emacs-Lisp",
         # see: http://pypi.python.org/pypi?%3Aaction=list_classifiers
     ],
-    install_requires=install_requires,
+    install_requires=[
+        "singledispatch; python_version < '3.4'",
+    ],
 )


### PR DESCRIPTION
Fix the conditional singledispatch requirement to be expressed using PEP 508 environment markers.  This fixes two problems with the current code:

1. String comparison of Python version meant that e.g. Python 3.10 compared older than 3.4.

2. Packages generated from the distribution would either contain the dependency or not depending on the Python version used to create the distribution rather than one that was used at install time.