### PR TITLE
Enable parsing of apostrophe in symbols

### DIFF
--- a/sexpdata.py
+++ b/sexpdata.py
@@ -638,7 +638,7 @@ class Parser(object):
 
     closing_brackets = set(BRACKETS.values())
     _atom_end_basic = \
-        set(BRACKETS) | set(closing_brackets) | set('"\'') | set(whitespace)
+        set(BRACKETS) | set(closing_brackets) | set('"') | set(whitespace)
     _atom_end_basic_or_escape_regexp = "|".join(map(re.escape,
                                                     _atom_end_basic | set('\\')))
     quote_or_escape_re = re.compile(r'"|\\')

--- a/test_sexpdata.py
+++ b/test_sexpdata.py
@@ -29,6 +29,7 @@ data_identity = [
     [Symbol('a'), Quoted([Symbol('b')]), Symbol('c')],
     [Symbol('a'), Quoted(Symbol('b')), Quoted(Symbol('c')), Symbol('d')],
     [Symbol('a'), Quoted(Symbol('b')), Symbol('c'), Quoted(Symbol('d'))],
+    [Symbol('set'), Symbol("set\'")],
     [bracket([1, 2, 3], '[')],
     [bracket([1, [2, bracket([3], '[')]], '[')],
     '""',


### PR DESCRIPTION
In Haskell and Lean, apostrophes can show up in symbols as long as it is not the first character. e.g.
`(run' state)`.

Previously parsing this will lead to an `ExpectSExp` error. With this patch it will parse as normal
```python3
>>> import sexpdata
>>> sexpdata.parse("foldM foldM'")
[Symbol('foldM'), Symbol("foldM'")]
```
the apostrophe is preferentially absorbed into the symbol before it if there's no space:
```python3
>>> sexpdata.parse("foldM'(1 2 3)")
[Symbol("foldM'"), [1, 2, 3]]
```