### PR TITLE
Also list keywords under dynamic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
         "Programming Language :: Lisp",
         "Programming Language :: Emacs-Lisp",
 ]
-dynamic = ["license"]
+dynamic = ["license", "keywords"]
 
 [project.urls]
 "Homepage" = "https://github.com/jd-boyd/sexpdata"


### PR DESCRIPTION
Apparently my old PR wasn't enough.

I cannot really test is right now, so could someone else see, whether this is enough?

Another way would probably be to remove [project] from the pyproject.toml as per the error message I got, yet I don't know, what this entails. In that case it is probably not necessary to list anything as dynamic here.




Error message:
```
          ********************************************************************************
          The following seems to be defined outside of `pyproject.toml`:
  
          `keywords = ['s-expression', 'lisp', 'parser']`
  
          According to the spec (see the link below), however, setuptools CANNOT
          consider this value unless `keywords` is listed as `dynamic`.
  
          https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
  
          To prevent this problem, you can list `keywords` under `dynamic` or alternatively
          remove the `[project]` table from your file and rely entirely on other means of
          configuration.
          ********************************************************************************

```