### PR TITLE
Added blocks to prevent automatic scientific notation or infinity con…

### DIFF
--- a/sexpdata.py
+++ b/sexpdata.py
@@ -730,6 +730,8 @@ class Parser(object):
             return int(token)
         except ValueError:
             try:
+                if 'e' in token.lower() or 'inf' in token.lower():
+                    raise ValueError('Invalid s-exp float')
                 return float(token)
             except ValueError:
                 return Symbol(token)

--- a/test_sexpdata.py
+++ b/test_sexpdata.py
@@ -207,6 +207,12 @@ def test_tosexp_value_errors():
         tosexp(Parens())
 
 
+def test_parse_float():
+    assert parse("-1.012") == [-1.012]
+    assert parse("2E22") == [Symbol("2E22")]
+    assert parse("inf") == [Symbol("inf")]
+
+
 def test_too_many_brackets():
     with pytest.raises(ExpectNothing):
         parse("(a b))")


### PR DESCRIPTION
I noticed a bug in where this: `(tedit 5E888720)` parsed to `[Symbol("tedit"), inf]`

This is because the parser tries to convert to a float and there's many expressions that are valid for the constructor of the Python float. It was determining "5E888720" as 5*e^888720. This PR blocks the float conversions that aren't part of the S-expression spec. According to Wikipedia, valid s-expression datatypes are:
>     Lists and pairs: (1 () (2 . 3) (4))
>     Symbols: with-hyphen ?@!$ |a symbol with spaces|
>     Strings: "Hello, world!"
>     Integers: -9876543210
>     Floating-point numbers: -0.0 6.28318 6.022e23

I also added unit tests